### PR TITLE
Add cleanup support

### DIFF
--- a/src/Bot/Features/Cleanup/ChannelCleanupService.cs
+++ b/src/Bot/Features/Cleanup/ChannelCleanupService.cs
@@ -1,0 +1,13 @@
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+
+namespace Mira.Features.Cleanup;
+
+public class ChannelCleanupService(CommandRepository commandRepository, ILogger<ChannelCleanupService> logger) : ICleanupService<SocketChannel>
+{
+    public Task ExecuteAsync(SocketChannel channel)
+    {
+        logger.LogInformation("[CLEANUP][{ChannelId} Channel destroyed event fired. Removing any associated subscriptions.", channel.Id);
+        return commandRepository.CleanupChannelAsync(channel.Id);
+    }
+}

--- a/src/Bot/Features/Cleanup/CommandRepository.cs
+++ b/src/Bot/Features/Cleanup/CommandRepository.cs
@@ -1,0 +1,27 @@
+using Dapper;
+using Mira.Data;
+
+namespace Mira.Features.Cleanup;
+
+public class CommandRepository(DbContext context)
+{
+    public async Task CleanupGuildAsync(ulong guildId)
+    {
+        using var connection = context.CreateConnection();
+        await connection.ExecuteAsync(
+            "DELETE FROM host WHERE guild_id = @guildId", new
+            {
+                guildId
+            });
+    }
+
+    public async Task CleanupChannelAsync(ulong channelId)
+    {
+        using var connection = context.CreateConnection();
+        await connection.ExecuteAsync(
+            "DELETE FROM subscription WHERE channel_id = @channelId", new
+            {
+                channelId
+            });
+    }
+}

--- a/src/Bot/Features/Cleanup/GuildCleanupService.cs
+++ b/src/Bot/Features/Cleanup/GuildCleanupService.cs
@@ -1,0 +1,13 @@
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+
+namespace Mira.Features.Cleanup;
+
+public class GuildCleanupService(CommandRepository commandRepository, ILogger<GuildCleanupService> logger) : ICleanupService<SocketGuild>
+{
+    public Task ExecuteAsync(SocketGuild guild)
+    {
+        logger.LogInformation("[CLEANUP][{GuildName}] Bot removed from guild. Removing any associated hosts and subscriptions.", guild.Name);
+        return commandRepository.CleanupChannelAsync(guild.Id);
+    }
+}

--- a/src/Bot/Features/Cleanup/ICleanupService.cs
+++ b/src/Bot/Features/Cleanup/ICleanupService.cs
@@ -1,0 +1,8 @@
+using Discord.WebSocket;
+
+namespace Mira.Features.Cleanup;
+
+public interface ICleanupService<T> where T : SocketEntity<ulong>
+{
+    Task ExecuteAsync(T socketEntity);
+}

--- a/src/Bot/Features/Cleanup/ServiceCollectionExtensions.cs
+++ b/src/Bot/Features/Cleanup/ServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Discord.WebSocket;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Mira.Features.Cleanup;
+
+public static class ServiceCollectionExtensions
+{
+    public static void AddCleanupServices(this IServiceCollection services)
+    {
+        services.AddTransient<CommandRepository>();
+        services.AddTransient<ICleanupService<SocketChannel>, ChannelCleanupService>();
+        services.AddTransient<ICleanupService<SocketGuild>, GuildCleanupService>();
+    }
+}


### PR DESCRIPTION
Adds two new services:
- GuildCleanupService: Removes any hosts (and subscriptions) when the GuildLeft (bot removed) event is fired.
- ChannelCleanupSerivce: Removes any subscriptions associated with a channel once the ChannelDestroyed event is fired.