### PR TITLE
Update to use events for triggering messages/db updated

### DIFF
--- a/src/Mira/Modules/ChangeTracking/ChangeTracking.Core/ChangeTrackingService.cs
+++ b/src/Mira/Modules/ChangeTracking/ChangeTracking.Core/ChangeTrackingService.cs
@@ -38,7 +38,7 @@ internal class ChangeTrackingService(
                 // Register events
                 stream.OnSendNewMessage += messageService.SendAsync;
                 stream.OnSendUpdateMessage += messageService.ModifyAsync;
-                stream.OnStateChange += command.UpsertStreamRecord;
+                stream.OnRecordStateChange += command.UpsertStreamRecord;
 
                 // Fire events
                 await stream.FireEventsAsync();

--- a/src/Mira/Modules/ChangeTracking/ChangeTracking.Core/Models/Stream.cs
+++ b/src/Mira/Modules/ChangeTracking/ChangeTracking.Core/Models/Stream.cs
@@ -34,7 +34,7 @@ internal class Stream
 
     public event SendNewMessageHandler? OnSendNewMessage;
     public event SendUpdatedMessageHandler? OnSendUpdateMessage;
-    public event Func<StreamRecord, Task>? OnStateChange; 
+    public event Func<StreamRecord, Task>? OnRecordStateChange; 
     public delegate Task<ulong?> SendNewMessageHandler(ulong channelId, StreamStatus status, string url, int viewerCount, TimeSpan duration, string? playing = null);
     public delegate Task SendUpdatedMessageHandler(ulong messageId, ulong channelId, StreamStatus status, string url, int viewerCount, TimeSpan duration, string? playing = null);
     
@@ -126,10 +126,10 @@ internal class Stream
             await OnSendUpdateMessage.Invoke(ExistingStreamMessageId!.Value, ChannelId, Status, Url, CurrentViewerCount ?? 0, Duration, Playing);
         }
 
-        if (RecordStateChange && OnStateChange is not null)
+        if (RecordStateChange && OnRecordStateChange is not null)
         {
             var record = ToStreamRecord();
-            await OnStateChange.Invoke(record);
+            await OnRecordStateChange.Invoke(record);
         }
     }
 }

--- a/src/Mira/Modules/ChangeTracking/ChangeTracking.Core/Models/Stream.cs
+++ b/src/Mira/Modules/ChangeTracking/ChangeTracking.Core/Models/Stream.cs
@@ -32,6 +32,12 @@ internal class Stream
         }
     }
 
+    public event SendNewMessageHandler? OnSendNewMessage;
+    public event SendUpdatedMessageHandler? OnSendUpdateMessage;
+    public event Func<StreamRecord, Task>? OnStateChange; 
+    public delegate Task<ulong?> SendNewMessageHandler(ulong channelId, StreamStatus status, string url, int viewerCount, TimeSpan duration, string? playing = null);
+    public delegate Task SendUpdatedMessageHandler(ulong messageId, ulong channelId, StreamStatus status, string url, int viewerCount, TimeSpan duration, string? playing = null);
+    
     private string HostUrl { get; }
     private int SubscriptionId { get; }
     private string StreamKey { get; }
@@ -48,16 +54,18 @@ internal class Stream
 
     // Messaging
     private ulong? MessageId { get; set; }
-    private bool MessageSent { get; set; }
+    // private bool MessageSent { get; set; }
 
-    // Simplified database stream status. The db only cares about online/offline. Further granularity is to allow for
-    // easy state management in this class (i.e. determine when to send a new message vs update)
+    // Simplified database stream status. The db only cares about online/offline. Further granularity (DetailedStreamStatus)
+    // is to allow for easy state management in this class (i.e. determine when to send a new message vs update)
     private StreamStatus Status => DetailedStreamStatus.ToStreamStatus();
     private DateTime StartTime => DetailedStreamStatus switch
     {
         DetailedStreamStatus.Starting => CurrentStartTime ?? DateTime.UtcNow,
         _ => ExistingStreamStartTime ?? DateTime.UtcNow
     };
+
+    private string Url => $"{HostUrl}/{StreamKey}";
     private TimeSpan Duration => (EndTime ?? DateTime.UtcNow).Subtract(StartTime);
     private DateTime? EndTime => DetailedStreamStatus switch
     {
@@ -70,54 +78,22 @@ internal class Stream
 
     // Internal meta
     private DetailedStreamStatus DetailedStreamStatus { get; set; }
-
-    // Offline is the only status we ignore
-    public bool StreamUpdated => DetailedStreamStatus != DetailedStreamStatus.Offline;
-    // We only send a new message when a stream is starting
-    public bool SendNewMessage => DetailedStreamStatus == DetailedStreamStatus.Starting;
-    public bool SendUpdateMessage => ExistingStreamMessageId is not null && DetailedStreamStatus == DetailedStreamStatus.Live ||
-                                     DetailedStreamStatus == DetailedStreamStatus.Ending;
     
-
-    public void MarkMessageSent(ulong messageId)
-    {
-        MessageId = messageId;
-        MessageSent = true;
-    }
-
-    public (ulong channelId, StreamStatus status, string url, int viewerCount, TimeSpan duration)
-        DeconstructIntoNewMessage()
-    {
-        if (!SendNewMessage)
-        {
-            throw new InvalidOperationException($"Stream not in valid state to deconstruct into new message format. Stream: {JsonSerializer.Serialize(this)}." );
-        }
-
-        var url = $"{HostUrl}/{StreamKey}";
-        return (ChannelId, Status, url, CurrentViewerCount ?? 0, Duration);
-    }
-
-    public (ulong messageId, ulong channelId, StreamStatus status, string url, int viewerCount, TimeSpan duration, string? playing)
-        DeconstructIntoUpdateMessage()
-    {
-        if (!SendUpdateMessage)
-        {
-            throw new InvalidOperationException($"Stream not in valid state to deconstruct into a message update format. Stream: {JsonSerializer.Serialize(this)}." );
-        }
-
-        var url = $"{HostUrl}/{StreamKey}";
-        return (ExistingStreamMessageId!.Value, ChannelId, Status, url, CurrentViewerCount ?? 0, Duration, Playing);
-    }
+    // Only send a new message when a stream is starting and a message hasn't already been sent
+    public bool SendNewMessage => DetailedStreamStatus == DetailedStreamStatus.Starting && 
+                                  MessageId is null;
+    public bool SendUpdateMessage => DetailedStreamStatus == DetailedStreamStatus.Live ||
+                                     DetailedStreamStatus == DetailedStreamStatus.Ending &&
+                                     ExistingStreamMessageId is not null;
+    
+    // We ignore offline and don't make updates unless there is a status change and a message Id present
+    private bool RecordStateChange => DetailedStreamStatus != DetailedStreamStatus.Offline &&
+                                      ExistingStreamStatus != Status &&
+                                      (ExistingStreamMessageId is not null || MessageId is not null);
 
     // Update this to return with Result<StreamRecord> type?
-    public StreamRecord ToStreamRecord()
+    private StreamRecord ToStreamRecord()
     {
-        if (ExistingStreamMessageId is null && MessageId is null)
-        {
-            throw new InvalidOperationException(
-                "Can't generate a stream record for a message that has never been sent.");
-        }
-
         // We prioritise any new messageIds first
         var messageId = (MessageId ?? ExistingStreamMessageId)!.Value;
 
@@ -135,5 +111,25 @@ internal class Stream
             EndTime = EndTime,
             Playing = playing
         };
+    }
+
+    public async Task FireEventsAsync()
+    {
+        if (SendNewMessage && OnSendNewMessage is not null)
+        {
+            // Need to await this, which means it needs to be in an answer func
+            MessageId = await OnSendNewMessage.Invoke(ChannelId, Status, Url, CurrentViewerCount ?? 0, Duration);
+        }
+
+        if (SendUpdateMessage && OnSendUpdateMessage is not null)
+        {
+            await OnSendUpdateMessage.Invoke(ExistingStreamMessageId!.Value, ChannelId, Status, Url, CurrentViewerCount ?? 0, Duration, Playing);
+        }
+
+        if (RecordStateChange && OnStateChange is not null)
+        {
+            var record = ToStreamRecord();
+            await OnStateChange.Invoke(record);
+        }
     }
 }

--- a/src/Mira/Modules/ChangeTracking/ChangeTracking.Tests/StreamTests.cs
+++ b/src/Mira/Modules/ChangeTracking/ChangeTracking.Tests/StreamTests.cs
@@ -7,9 +7,12 @@ namespace ChangeTracking.Tests;
 public class StreamTests
 {
     [Fact]
-    public void DeconstructIntoNewMessage_ShouldReturnCorrectTuple_WhenStreamIsStarting()
+    public async Task OnSendNewMessage_ShouldFire_WhenStreamIsStarting()
     {
         var hostUrl = "exampleHostUrl";
+        var eventRaised = false;
+        ulong? channelId = null;
+        int? viewerCount = null;
 
         var subscription = new Subscription
         {
@@ -27,47 +30,28 @@ public class StreamTests
         };
 
         var stream = new Stream(hostUrl, subscription, null, currentStream);
-        var result = stream.DeconstructIntoNewMessage();
 
-        Assert.Equal(subscription.ChannelId, result.channelId);
-        Assert.Equal(currentStream.ViewerCount, result.viewerCount);
-    }
-    
-    [Fact]
-    public void DeconstructIntoNewMessage_ShouldThrowException_WhenStreamIsNotStarting()
-    {
-        var hostUrl = "exampleHostUrl";
-
-        var subscription = new Subscription
+        stream.OnSendNewMessage += (eventChannelId, _, _, eventViewers, _, _) =>
         {
-            Id = 1,
-            StreamKey = "streamkey",
-            ChannelId = 54321
+            eventRaised = true;
+            channelId = eventChannelId;
+            viewerCount = eventViewers;
+            return Task.FromResult((ulong?)12345);
         };
+
+        await stream.FireEventsAsync();
         
-        var existingStream = new StreamRecord
-        {
-            Status = StreamStatus.Live
-        };
-
-        var currentStream = new KeySummary
-        {
-            FirstSeenEpoch = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
-            VideoStreams = [
-                new VideoStream { LastKeyFrameSeen = DateTime.UtcNow }
-            ]
-        };
-
-        var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
-
-        Assert.Throws<InvalidOperationException>(() => stream.DeconstructIntoNewMessage());
+        Assert.True(eventRaised);
+        Assert.Equal(subscription.ChannelId, channelId);
+        Assert.Equal(currentStream.ViewerCount, viewerCount);
     }
     
     [Fact]
-    public void DeconstructIntoUpdateMessage_ShouldReturnCorrectTuple_WhenStreamIsLive()
+    public async Task OnSendNewMessage_ShouldNotFire_WhenStreamIsLive()
     {
         var hostUrl = "exampleHostUrl";
         var viewers = 150;
+        var eventRaised = false;
 
         var subscription = new Subscription
         {
@@ -94,18 +78,76 @@ public class StreamTests
         };
         
         var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
-        var result = stream.DeconstructIntoUpdateMessage();
+        stream.OnSendNewMessage += (_, _, _, _, _, _) =>
+        {
+            eventRaised = true;
+            return Task.FromResult((ulong?)12345);
+        };
 
-        Assert.Equal(existingStream.MessageId, result.messageId);
-        Assert.Equal(viewers, result.viewerCount);
-        Assert.Equal(StreamStatus.Live, result.status);
+        await stream.FireEventsAsync();
+        
+        Assert.False(eventRaised);
+    }
+
+    [Fact]
+    public async Task OnSendUpdateMessage_ShouldFire_WhenStreamIsLive()
+    {
+        var hostUrl = "exampleHostUrl";
+        var eventRaised = false;
+        int? viewerCount = null;
+        ulong? messageId = null;
+        StreamStatus? status = null;
+
+        var subscription = new Subscription
+        {
+            Id = 1,
+            StreamKey = "streamkey",
+            ChannelId = 54321
+        };
+        
+        // Existing stream is live
+        var existingStream = new StreamRecord
+        {
+            MessageId = 12345,
+            Status = StreamStatus.Live
+        };
+        
+        // Current stream is live
+        var currentStream = new KeySummary
+        {
+            FirstSeenEpoch = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            VideoStreams = [
+                new VideoStream { LastKeyFrameSeen = DateTime.UtcNow }
+            ],
+            WhepSessions = Enumerable.Range(1, 150).Select(_ => new Viewer()).ToArray()
+        };
+        
+        var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
+        stream.OnSendUpdateMessage += (eventMessageId, _, eventStatus, _, eventViewerCount, _, _) =>
+        {
+            eventRaised = true;
+            messageId = eventMessageId;
+            status = eventStatus;
+            viewerCount = eventViewerCount;
+            return Task.CompletedTask;
+        };
+
+        await stream.FireEventsAsync();
+        
+        Assert.True(eventRaised);
+        Assert.Equal(existingStream.MessageId, messageId);
+        Assert.Equal(StreamStatus.Live, status);
+        Assert.Equal(currentStream.ViewerCount, viewerCount);
     }
     
     [Fact]
-    public void DeconstructIntoUpdateMessage_ShouldReturnCorrectTuple_WhenStreamIsEnding()
+    public async Task OnSendUpdateMessage_ShouldFire_WhenStreamIsEnding()
     {
         var hostUrl = "exampleHostUrl";
         var existingViewers = 150;
+        var eventRaised = false;
+        StreamStatus? status = null;
+        ulong? messageId = null;
         
         var subscription = new Subscription
         {
@@ -126,17 +168,27 @@ public class StreamTests
         var currentStream = new KeySummary();
 
         var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
-        var result = stream.DeconstructIntoUpdateMessage();
+        stream.OnSendUpdateMessage += (eventMessageId, channelId, eventStatus, url, count, duration, playing) =>
+        {
+            eventRaised = true;
+            messageId = eventMessageId;
+            status = eventStatus;
+            return Task.CompletedTask;
+        };
 
-        Assert.Equal(existingStream.MessageId, result.messageId);
-        Assert.Equal(StreamStatus.Offline, result.status);
-        Assert.NotEqual(existingViewers, result.viewerCount);
+        await stream.FireEventsAsync();
+
+        Assert.True(eventRaised);
+        Assert.Equal(existingStream.MessageId, messageId);
+        Assert.Equal(StreamStatus.Offline, status);
     }
     
     [Fact]
-    public void DeconstructIntoUpdateMessage_ShouldThrowException_WhenStreamIsOffline()
+    public async Task OnSendUpdateMessage_ShouldNotFire_WhenStreamIsOffline()
     {
         var hostUrl = "exampleHostUrl";
+        var eventRaised = false;
+        
         var subscription = new Subscription
         {
             Id = 1,
@@ -155,14 +207,22 @@ public class StreamTests
         var currentStream = new KeySummary();
 
         var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
+        stream.OnSendUpdateMessage += (_, _, _, _, _, _, _) =>
+        {
+            eventRaised = true;
+            return Task.CompletedTask;
+        };
+
+        await stream.FireEventsAsync();
         
-        Assert.Throws<InvalidOperationException>(() => stream.DeconstructIntoUpdateMessage());
+        Assert.False(eventRaised);
     }
     
     [Fact]
-    public void DeconstructIntoUpdateMessage_ShouldThrowException_WhenNoExistingStream()
+    public async Task OnSendUpdateMessage_ShouldNotFire_WhenNoExistingStream()
     {
         var hostUrl = "exampleHostUrl";
+        var eventRaised = false;
 
         var subscription = new Subscription
         {
@@ -184,15 +244,24 @@ public class StreamTests
         };
 
         var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
-        
-        Assert.Throws<InvalidOperationException>(() => stream.DeconstructIntoUpdateMessage());
+        stream.OnSendUpdateMessage += (_, _, _, _, _, _, _) =>
+        {
+            eventRaised = true;
+            return Task.CompletedTask;
+        };
+
+        await stream.FireEventsAsync();
+
+        Assert.False(eventRaised);
     }
     
     [Fact]
-    public void ToStreamRecord_ShouldReturnStreamRecord_WhenNewMessageIsMarkedSent()
+    public async Task OnRecordStateChange_ShouldFire_WhenStreamStatusChangesAndMessageSent()
     {
         var hostUrl = "exampleHostUrl";
         var messageId = 12345UL;
+        var eventRaised = false;
+        ulong? recordMessageId = null;
 
         var subscription = new Subscription
         {
@@ -201,8 +270,10 @@ public class StreamTests
             ChannelId = 54321
         };
 
+        // Previously offline
         StreamRecord? existingStream = null;
 
+        // Current stream online
         var currentStream = new KeySummary
         {
             FirstSeenEpoch = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
@@ -212,19 +283,28 @@ public class StreamTests
         };
 
         var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
-        stream.MarkMessageSent(messageId);
+        stream.OnSendNewMessage += (_, _, _, _, _, _) => Task.FromResult((ulong?)messageId);
+        
+        stream.OnRecordStateChange += record =>
+        {
+            recordMessageId = record.MessageId;
+            eventRaised = true;
+            return Task.CompletedTask;
+        };
 
-        var result = stream.ToStreamRecord();
+        await stream.FireEventsAsync();
 
-        Assert.Null(result.Id);
-        Assert.Equal(messageId, result.MessageId);
+        Assert.True(eventRaised);
+        Assert.Equal(messageId, recordMessageId);
     }
     
-        
     [Fact]
-    public void ToStreamRecord_ShouldThrowException_WhenNewMessageIdIsNotMarkedSent()
+    public async Task OnRecordStateChange_ShouldNotFire_WhenStreamStatusChangesAndMessageNotSent()
     {
         var hostUrl = "exampleHostUrl";
+        var messageId = 12345UL;
+        var eventRaised = false;
+        ulong? recordMessageId = null;
 
         var subscription = new Subscription
         {
@@ -233,27 +313,38 @@ public class StreamTests
             ChannelId = 54321
         };
 
-        // No existing stream
+        // Previously offline
         StreamRecord? existingStream = null;
 
-        // Current stream is live
+        // Current stream online
         var currentStream = new KeySummary
         {
             FirstSeenEpoch = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
             VideoStreams = [
                 new VideoStream { LastKeyFrameSeen = DateTime.UtcNow }
-            ],
+            ]
         };
 
         var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
+        
+        // No .OnSendNewMessage event registered, so state change should not be recorded
+        stream.OnRecordStateChange += _ =>
+        {
+            eventRaised = true;
+            return Task.CompletedTask;
+        };
 
-        Assert.Throws<InvalidOperationException>(() => stream.ToStreamRecord());
+        await stream.FireEventsAsync();
+
+        Assert.False(eventRaised);
     }
     
     [Fact]
-    public void ToStreamRecord_ShouldReturnStreamRecord_WhenRecordedMessageIdIsPresent()
+    public async Task OnRecordStateChange_ShouldNotFire_WhenStreamStatusHasNotChanged()
     {
         var hostUrl = "exampleHostUrl";
+        var messageId = 12345UL;
+        var eventRaised = false;
 
         var subscription = new Subscription
         {
@@ -261,12 +352,12 @@ public class StreamTests
             StreamKey = "streamkey",
             ChannelId = 54321
         };
-        
+
+        // Existing stream is live
         var existingStream = new StreamRecord
         {
-            Id = 1,
             MessageId = 12345,
-            SubscriptionId = 1
+            Status = StreamStatus.Live
         };
 
         var currentStream = new KeySummary
@@ -278,19 +369,25 @@ public class StreamTests
         };
 
         var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
-        var result = stream.ToStreamRecord();
+        stream.OnRecordStateChange += _ =>
+        {
+            eventRaised = true;
+            return Task.CompletedTask;
+        };
 
-        Assert.Equal(existingStream.Id, result.Id);
-        Assert.Equal(existingStream.SubscriptionId, result.SubscriptionId);
-        Assert.Equal(existingStream.MessageId, result.MessageId);
+        await stream.FireEventsAsync();
+
+        Assert.False(eventRaised);
     }
-
+    
     [Fact]
-    public void ToStreamRecord_ShouldUpdateExistingStartTimeEndTime_WhenNewStreamIsStarting()
+    public async Task OnRecordStateChange_ShouldUpdateExistingStartTimeEndTime_WhenNewStreamIsStarting()
     {
         var hostUrl = "exampleHostUrl";
         var existingStartTime = new DateTime(2020, 03, 11);
         var existingEndTime = new DateTime(2020, 03, 12);
+        var eventRaised = false;
+        (DateTime startTime, DateTime? endTime) result = (default, default);
 
         var subscription = new Subscription
         {
@@ -320,20 +417,31 @@ public class StreamTests
         };
 
         var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
-        stream.MarkMessageSent(54321);
+        stream.OnSendNewMessage += (_, _, _, _, _, _) => Task.FromResult((ulong?)54321);
+        stream.OnRecordStateChange += record =>
+        {
+            eventRaised = true;
+            result.startTime = record.StartTime;
+            result.endTime = record.EndTime;
+            
+            return Task.CompletedTask;
+        };
 
-        var result = stream.ToStreamRecord();
+        await stream.FireEventsAsync();
 
-        Assert.NotEqual(existingStartTime, result.StartTime);
-        Assert.NotEqual(existingEndTime, result.EndTime);
-        Assert.Null(result.EndTime);
+        Assert.True(eventRaised);
+        Assert.NotEqual(existingStartTime, result.startTime);
+        Assert.NotEqual(existingEndTime, result.endTime);
+        Assert.Null(result.endTime);
     }
     
     [Fact]
-    public void ToStreamRecord_ShouldSetNewMessageId_WhenNewStreamIsStarting()
+    public async Task OnRecordStateChange_ShouldSetNewMessageId_WhenNewStreamIsStarting()
     {
         var hostUrl = "exampleHostUrl";
         var newMessageId = 54321UL;
+        var eventRaised = false;
+        ulong? recordedMessageId = null;
         
         var subscription = new Subscription
         {
@@ -362,57 +470,27 @@ public class StreamTests
         };
 
         var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
-        stream.MarkMessageSent(newMessageId);
+        stream.OnSendNewMessage += (_, _, _, _, _, _) => Task.FromResult((ulong?)54321);
+        stream.OnRecordStateChange += record =>
+        {
+            eventRaised = true;
+            recordedMessageId = record.MessageId;
+            
+            return Task.CompletedTask;
+        };
 
-        var result = stream.ToStreamRecord();
+        await stream.FireEventsAsync();
 
-        Assert.Equal(newMessageId, result.MessageId);
+        Assert.True(eventRaised);
+        Assert.Equal(newMessageId, recordedMessageId);
     }
-    
+
     [Fact]
-    public void ToStreamRecord_ShouldUseExistingStartTime_WhenStreamIsUpdating()
+    public async Task ToStreamRecord_ShouldUseExistingMessageId_WhenStreamIsUpdating()
     {
         var hostUrl = "exampleHostUrl";
-        var existingStartTime = new DateTime(2020, 03, 11);
-
-        var subscription = new Subscription
-        {
-            Id = 1,
-            StreamKey = "streamkey",
-            ChannelId = 54321
-        };
-        
-        // Existing live stream
-        var existingStream = new StreamRecord
-        {
-            Id = 1,
-            MessageId = 12345,
-            SubscriptionId = 1,
-            StartTime = existingStartTime,
-            EndTime = null,
-            Status = StreamStatus.Live
-        };
-
-        // Current live stream
-        var currentStream = new KeySummary
-        {
-            FirstSeenEpoch = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
-            VideoStreams = [
-                new VideoStream { LastKeyFrameSeen = DateTime.UtcNow }
-            ]
-        };
-
-        var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
-        var result = stream.ToStreamRecord();
-
-        Assert.Equal(existingStartTime, result.StartTime);
-        Assert.Null(result.EndTime);
-    }
-    
-    [Fact]
-    public void ToStreamRecord_ShouldUseExistingMessageId_WhenStreamIsUpdating()
-    {
-        var hostUrl = "exampleHostUrl";
+        var eventRaised = false;
+        ulong? recordedMessageId = null;
 
         var subscription = new Subscription
         {
@@ -432,25 +510,30 @@ public class StreamTests
             Status = StreamStatus.Live
         };
 
-        // Current live stream
-        var currentStream = new KeySummary
-        {
-            VideoStreams = [
-                new VideoStream { LastKeyFrameSeen = DateTime.UtcNow }
-            ]
-        };
+        // Current offline stream
+        var currentStream = new KeySummary();
 
         var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
-        var result = stream.ToStreamRecord();
+        stream.OnSendUpdateMessage += (id, channelId, status, url, count, duration, playing) => Task.CompletedTask;
+        stream.OnRecordStateChange += record =>
+        {
+            eventRaised = true;
+            recordedMessageId = record.MessageId;
+            return Task.CompletedTask;
+        };
 
-        Assert.Equal(existingStream.MessageId, result.MessageId);
+        await stream.FireEventsAsync();
+            
+        Assert.Equal(existingStream.MessageId, recordedMessageId);
     }
     
     [Fact]
-    public void ToStreamRecord_ShouldMarkCurrentStreamOffline_WhenTimeSinceLastFrameOutOfWindow()
+    public async Task ToStreamRecord_ShouldMarkCurrentStreamOffline_WhenTimeSinceLastFrameOutOfWindow()
     {
         var hostUrl = "exampleHostUrl";
         var secondsSinceLastFrame = 30;
+        var eventRaised = false;
+        StreamStatus? recordedStreamStatus = null;
 
         var subscription = new Subscription
         {
@@ -482,8 +565,17 @@ public class StreamTests
         };
 
         var stream = new Stream(hostUrl, subscription, existingStream, currentStream);
-        var result = stream.ToStreamRecord();
+        stream.OnSendUpdateMessage += (id, channelId, status, url, count, duration, playing) => Task.CompletedTask;
+        stream.OnRecordStateChange += record =>
+        {
+            eventRaised = true;
+            recordedStreamStatus = record.Status;
+            return Task.CompletedTask;
+        };
 
-        Assert.Equal(StreamStatus.Offline, result.Status);
+        await stream.FireEventsAsync();
+
+        Assert.True(eventRaised);
+        Assert.Equal(StreamStatus.Offline, recordedStreamStatus);
     }
 }

--- a/src/Mira/Modules/Commands/Commands.Core/Playing/SlashCommand.cs
+++ b/src/Mira/Modules/Commands/Commands.Core/Playing/SlashCommand.cs
@@ -11,9 +11,9 @@ public class SlashCommand(QueryRepository queryRepository, CommandRepository com
     : ISlashCommand, ISelectable
 {
     public string Name => "playing";
-    public string PlayingOptionName = "playing";
-    public char Divider = ':';
-    
+    private const string PlayingOptionName = "playing";
+    private const char Divider = ':';
+
     public ApplicationCommandProperties BuildCommand() => 
         new SlashCommandBuilder()
             .WithName(Name)

--- a/src/Mira/Modules/Commands/Commands.Core/Playing/SlashCommand.cs
+++ b/src/Mira/Modules/Commands/Commands.Core/Playing/SlashCommand.cs
@@ -117,10 +117,12 @@ public class SlashCommand(QueryRepository queryRepository, CommandRepository com
             return;
         }
         
+        logger.LogInformation("[SLASH-COMMAND][{Name}] User {User}({UserId}) updated the stream key {streamKey} to playing: {playing}", Name, component.User.Username, component.User.Id, stream.Key, playing);
+        
         // Clear the original component
         await component.ModifyOriginalResponseAsync(message =>
         {
-            message.Content = $"Update requested for `{stream.Url}`";
+            message.Content = $"Updating `{stream.Url}`, setting playing: {playing}";
             message.Components = new ComponentBuilder().Build();
         });
 

--- a/src/Mira/Modules/Messaging/Messaging.Core/MessageService.cs
+++ b/src/Mira/Modules/Messaging/Messaging.Core/MessageService.cs
@@ -29,14 +29,14 @@ public class MessageService(DiscordSocketClient discord, ILogger<MessageService>
         return message.Id;
     }
 
-    public async Task<ulong?> ModifyAsync(ulong messageId, ulong channelId, StreamStatus status, string url, int viewers, TimeSpan duration, string? playing)
+    public async Task ModifyAsync(ulong messageId, ulong channelId, StreamStatus status, string url, int viewers, TimeSpan duration, string? playing)
     {
         // TODO: Check validity off messageId too
         var channel = GetChannel(channelId);
         if (channel is null)
         {
             logger.LogCritical("[MESSAGE-SERVICE] Failed to retrieve channel for stream {Url}. Channel: {Channel}", url, channelId);
-            return null;
+            return;
         }
         
         var embed = status switch
@@ -46,8 +46,7 @@ public class MessageService(DiscordSocketClient discord, ILogger<MessageService>
             _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
         };
 
-        var message = await channel.ModifyMessageAsync(messageId, properties => properties.Embed = embed);
-        return message.Id;
+        await channel.ModifyMessageAsync(messageId, properties => properties.Embed = embed);
     }
 
     private IMessageChannel? GetChannel(ulong channelId) => discord.GetChannel(channelId) as IMessageChannel;

--- a/src/Mira/Modules/Shared/Shared.Core/Interfaces/IMessageService.cs
+++ b/src/Mira/Modules/Shared/Shared.Core/Interfaces/IMessageService.cs
@@ -3,5 +3,5 @@ namespace Shared.Core.Interfaces;
 public interface IMessageService
 {
     Task<ulong?> SendAsync(ulong channelId, StreamStatus status, string url, int viewers, TimeSpan duration, string? playing = null);
-    Task<ulong?> ModifyAsync(ulong messageId, ulong channelId, StreamStatus status, string url, int viewers, TimeSpan duration, string? playing = null);
+    Task ModifyAsync(ulong messageId, ulong channelId, StreamStatus status, string url, int viewers, TimeSpan duration, string? playing = null);
 }


### PR DESCRIPTION
- Update to allow for NewMessage, UpdateMessage and UpsertRecord events to be registered with the stream model, rather than handled by the ChangeTrackingService
- As a result of this update, stream could be simplified and some more properties made internal
- Updated Stream tests
- Updated the return type of the MessageService.ModifyAsync as the returned Id was always discarded
- Minor wording updates to the `/playing` command