### PR TITLE
Cancelled tokens are not removed from the list of subscribed hosts

### DIFF
--- a/src/Mira/Modules/Polling/Polling.Core/PollingService.cs
+++ b/src/Mira/Modules/Polling/Polling.Core/PollingService.cs
@@ -19,14 +19,15 @@ public class PollingService(
     {
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(options.Value.NewHostIntervalSeconds));
 
-        var subscribedHosts = new Dictionary<string, CancellationTokenSource>();
+        var subscribedHosts = new SubscriptionTracker(logger);
         do
         {
             logger.LogInformation("[HOST-POLLING] Checking for new hosts...");
             var hosts = await query.GetHostsAsync();
+            
             foreach (var host in hosts)
             {
-                if (subscribedHosts.ContainsKey(host.Url))
+                if (subscribedHosts.Contains(host.Url))
                 {
                     continue;
                 }
@@ -35,21 +36,12 @@ public class PollingService(
                     "[HOST-POLLING] New host found: {Host}. Creating subscription. Interval: {Seconds}s", host.Url,
                     host.PollIntervalSeconds);
 
-                // Create a child of the provided cancellation token
-                var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
-                subscribedHosts[host.Url] = cancellationSource;
-                _ = SubscribeToHostAsync(host, cancellationSource.Token);
+                var cancellationToken = subscribedHosts.Register(host.Url, stoppingToken);
+                _ = SubscribeToHostAsync(host, cancellationToken);
             }
 
-            // These are hosts that were previously subscribed but have since been removed from the DB
-            var staleHosts = subscribedHosts
-                .Where(subscription =>
-                    !hosts.Select(host => host.Url).Contains(subscription.Key)
-                )
-                .Select(entry => (entry.Key, entry.Value))
-                .ToArray();
-
-            await CancelSubscriptionsAsync(staleHosts);
+            var activeHostUrls = hosts.Select(host => host.Url);
+            await subscribedHosts.Cleanup(activeHostUrls);
             await timer.WaitForNextTickAsync(stoppingToken);
         } while (!stoppingToken.IsCancellationRequested);
     }
@@ -62,19 +54,5 @@ public class PollingService(
             await service.ExecuteAsync(host.Url);
             await timer.WaitForNextTickAsync(stoppingToken);
         } while (!stoppingToken.IsCancellationRequested);
-    }
-
-    private Task CancelSubscriptionsAsync(
-        IEnumerable<(string hostUrl, CancellationTokenSource cancellationSource)> staleHosts)
-    {
-        var cancellationTasks = staleHosts.Select(entry =>
-        {
-            var (url, cancellationSource) = entry;
-            logger.LogInformation("[HOST-POLLING][{Host}] Host no longer registered in the database. Cancelling.",
-                url);
-            return cancellationSource.CancelAsync();
-        });
-
-        return Task.WhenAll(cancellationTasks);
     }
 }

--- a/src/Mira/Modules/Polling/Polling.Core/PollingService.cs
+++ b/src/Mira/Modules/Polling/Polling.Core/PollingService.cs
@@ -41,7 +41,7 @@ public class PollingService(
             }
 
             var activeHostUrls = hosts.Select(host => host.Url);
-            await subscribedHosts.Cleanup(activeHostUrls);
+            await subscribedHosts.CleanupAsync(activeHostUrls);
             await timer.WaitForNextTickAsync(stoppingToken);
         } while (!stoppingToken.IsCancellationRequested);
     }

--- a/src/Mira/Modules/Polling/Polling.Core/SubscriptionTracker.cs
+++ b/src/Mira/Modules/Polling/Polling.Core/SubscriptionTracker.cs
@@ -27,13 +27,13 @@ public class SubscriptionTracker(ILogger logger)
 
     public bool Contains(string hostUrl) => _subscriptions.ContainsKey(hostUrl);
 
-    public async Task Cleanup(IEnumerable<string> activeHostUrls)
+    public async Task CleanupAsync(IEnumerable<string> activeHostUrls)
     {
-        await ClearStaleHosts(activeHostUrls);
-        ClearCancelledHosts();
+        await CleanupStaleHostsAsync(activeHostUrls);
+        CleanupCancelledHosts();
     }
 
-    private void ClearCancelledHosts()
+    private void CleanupCancelledHosts()
     {
         var staleHosts = _subscriptions
             .Where(subscription => subscription.Value.IsCancellationRequested);
@@ -46,7 +46,7 @@ public class SubscriptionTracker(ILogger logger)
         }
     }
 
-    private Task ClearStaleHosts(IEnumerable<string> activeHostUrls)
+    private Task CleanupStaleHostsAsync(IEnumerable<string> activeHostUrls)
     {
         var cancellationTasks = _subscriptions
             .Where(subscription => !activeHostUrls.Contains(subscription.Key))

--- a/src/Mira/Modules/Polling/Polling.Core/SubscriptionTracker.cs
+++ b/src/Mira/Modules/Polling/Polling.Core/SubscriptionTracker.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Logging;
+
+namespace Polling.Core;
+
+public class SubscriptionTracker(ILogger logger)
+{
+    private readonly Dictionary<string, CancellationTokenSource> _subscriptions = new();
+
+    public CancellationToken Register(string hostUrl, CancellationToken baseCancellationToken)
+    {
+        var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(baseCancellationToken);
+        _subscriptions.Add(hostUrl, cancellationSource);
+        logger.LogInformation("[SUBSCRIPTION-TRACKER][{Host}] Subscription registered.", hostUrl);
+        return cancellationSource.Token;
+    }
+    
+    public async Task Unsubscribe(string hostUrl)
+    {
+        if (!_subscriptions.TryGetValue(hostUrl, out var cancellationTokenSource))
+        {
+            throw new InvalidOperationException($"Unable to find subscription under key: {hostUrl}");
+        }
+
+        await cancellationTokenSource.CancelAsync();
+        _subscriptions.Remove(hostUrl);
+    }
+
+    public bool Contains(string hostUrl) => _subscriptions.ContainsKey(hostUrl);
+
+    public async Task Cleanup(IEnumerable<string> activeHostUrls)
+    {
+        await ClearStaleHosts(activeHostUrls);
+        ClearCancelledHosts();
+    }
+
+    private void ClearCancelledHosts()
+    {
+        var staleHosts = _subscriptions
+            .Where(subscription => subscription.Value.IsCancellationRequested);
+        
+        foreach (var staleHost in staleHosts)
+        {
+            logger.LogInformation("[SUBSCRIPTION-TRACKER][{Host}] Cancellation token has been triggered. Removing from subscribed hosts.",
+                staleHost.Key);
+            _subscriptions.Remove(staleHost.Key);
+        }
+    }
+
+    private Task ClearStaleHosts(IEnumerable<string> activeHostUrls)
+    {
+        var cancellationTasks = _subscriptions
+            .Where(subscription => !activeHostUrls.Contains(subscription.Key))
+            .Select(entry =>
+            {
+                logger.LogInformation("[SUBSCRIPTION-TRACKER][{Host}] Host no longer registered in the database. Cancelling.",
+                    entry.Key);
+                return entry.Value.CancelAsync();
+            });
+
+        return Task.WhenAll(cancellationTasks);
+    }
+}


### PR DESCRIPTION
Fix a bug that would prevent subscriptions from re-triggering after being cancelled as they would remain in the `subscribedHosts` list.

This is a temporary fix as this entire section needs re-thinking.