### PR TITLE
Custom Auth Head support with fallbacks

### DIFF
--- a/src/Mira/Bot/Data/init.sql
+++ b/src/Mira/Bot/Data/init.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS host (
     id INTEGER PRIMARY KEY NOT NULL,
     url TEXT NOT NULL,
     poll_interval_seconds INTEGER DEFAULT 30 NOT NULL,
+    auth_header TEXT NULL,
     guild_id INTEGER NOT NULL,
     created_by INTEGER NOT NULL,
     UNIQUE (url, guild_id)

--- a/src/Mira/Bot/appsettings.json
+++ b/src/Mira/Bot/appsettings.json
@@ -15,5 +15,8 @@
   "PollingOptions": {
     "NewHostIntervalSeconds": 45,
     "NewHostValidationTimeoutSeconds": 1
+  }, 
+  "FallbackAuthHeaders": {
+    "www_urltotarget_com": "auth-header"
   }
 }

--- a/src/Mira/Modules/ChangeTracking/ChangeTracking.Core/BroadcastBoxClient.cs
+++ b/src/Mira/Modules/ChangeTracking/ChangeTracking.Core/BroadcastBoxClient.cs
@@ -1,31 +1,38 @@
 using System.Net.Http.Json;
 using ChangeTracking.Core.Models;
 using Microsoft.Extensions.Logging;
+using Host = Shared.Core.Models.Host;
 
 namespace ChangeTracking.Core;
 
 internal class BroadcastBoxClient(IHttpClientFactory httpClientFactory, ILogger<BroadcastBoxClient> logger)
 {
-    internal async Task<KeySummary[]> GetStreamsAsync(string hostUrl)
+    internal async Task<KeySummary[]> GetStreamsAsync(Host host)
     {
-        if (string.IsNullOrWhiteSpace(hostUrl))
+        if (string.IsNullOrWhiteSpace(host.Url))
         {
             return [];
         }
 
-        var client = httpClientFactory.CreateClient(hostUrl);
+        var client = httpClientFactory.CreateClient(host.Url);
         
-        var result = await client.GetAsync($"{hostUrl}/api/status");
-        if (!result.IsSuccessStatusCode)
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{host.Url}/api/status");
+        if (!string.IsNullOrWhiteSpace(host.AuthHeader))
         {
-            logger.LogError("[BROADCASTBOX-CLIENT] Failed to make get request to {Host}/api/status. Status code: {Status}", hostUrl, result.StatusCode);
+            request.Headers.TryAddWithoutValidation("Authorization", host.AuthHeader);
+        }
+        
+        var response = await client.SendAsync(request);
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogError("[BROADCASTBOX-CLIENT] Failed to make get request to {Host}/api/status. Status code: {Status}", host.Url, response.StatusCode);
             return [];
         }
 
-        var statuses = await result.Content.ReadFromJsonAsync<KeySummary[]>();
+        var statuses = await response.Content.ReadFromJsonAsync<KeySummary[]>();
         if (statuses is null)
         {
-            var rawResponse = await result.Content.ReadAsStringAsync();
+            var rawResponse = await response.Content.ReadAsStringAsync();
             logger.LogError("[BROADCASTBOX-CLIENT] Failed to extract KeyStatus models from JSON. Raw response: {Response}", rawResponse);
         }
 

--- a/src/Mira/Modules/Commands/Commands.Core/AddHost/BroadcastBoxClient.cs
+++ b/src/Mira/Modules/Commands/Commands.Core/AddHost/BroadcastBoxClient.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using Commands.Core.AddHost.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -9,7 +10,7 @@ public class BroadcastBoxClient(
     ILogger<BroadcastBoxClient> logger,
     IOptions<PollingOptions> options)
 {
-    public async Task<bool> IsVerifiedBroadcastBoxHostAsync(string hostUrl)
+    public async Task<bool> IsVerifiedBroadcastBoxHostAsync(string hostUrl, string? authHeader = null)
     {
         if (string.IsNullOrWhiteSpace(hostUrl))
         {
@@ -23,8 +24,13 @@ public class BroadcastBoxClient(
 
         try
         {
-            var result = await client.GetAsync($"{hostUrl}/api/status");
-            return result.IsSuccessStatusCode;
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{hostUrl}/api/status");
+            if (!string.IsNullOrWhiteSpace(authHeader))
+            {
+                request.Headers.TryAddWithoutValidation("Authorization", authHeader);
+            }
+            var response = await client.SendAsync(request);
+            return response.IsSuccessStatusCode;
         }
         catch (TaskCanceledException ex)
         {

--- a/src/Mira/Modules/Commands/Commands.Core/AddHost/Models/Host.cs
+++ b/src/Mira/Modules/Commands/Commands.Core/AddHost/Models/Host.cs
@@ -1,3 +1,3 @@
 namespace Commands.Core.AddHost.Models;
 
-public record Host(string Url, int PollIntervalSeconds, ulong GuildId, ulong CreatedBy);
+public record Host(string Url, int PollIntervalSeconds, ulong GuildId, ulong CreatedBy, string? AuthHeader = null);

--- a/src/Mira/Modules/Commands/Commands.Core/AddHost/Repositories/CommandRepository.cs
+++ b/src/Mira/Modules/Commands/Commands.Core/AddHost/Repositories/CommandRepository.cs
@@ -11,11 +11,12 @@ public class CommandRepository(DbContext context)
         using var connection = context.CreateConnection();
         await connection.ExecuteAsync(
             @"INSERT INTO host
-                (url, poll_interval_seconds, guild_id, created_by)
-                VALUES (@url, @pollIntervalSeconds, @guildId, @createdBy)", new
+                (url, poll_interval_seconds, auth_header, guild_id, created_by)
+                VALUES (@url, @pollIntervalSeconds, @authHeader, @guildId, @createdBy)", new
             {
                 url = host.Url,
                 pollIntervalSeconds = host.PollIntervalSeconds,
+                authHeader = host.AuthHeader,
                 guildId = host.GuildId,
                 createdBy = host.CreatedBy
             });

--- a/src/Mira/Modules/Polling/Polling.Core/ISubscriptionManager.cs
+++ b/src/Mira/Modules/Polling/Polling.Core/ISubscriptionManager.cs
@@ -1,5 +1,5 @@
 
-using Polling.Core.Models;
+using Shared.Core.Models;
 
 namespace Polling.Core;
 

--- a/src/Mira/Modules/Polling/Polling.Core/Repositories/QueryRepository.cs
+++ b/src/Mira/Modules/Polling/Polling.Core/Repositories/QueryRepository.cs
@@ -10,7 +10,7 @@ public class QueryRepository(DbContext context)
     {
         using var connection = context.CreateConnection();
         var results = await connection.QueryAsync<Host>(
-            @"SELECT url, MIN(poll_interval_seconds) pollIntervalSeconds
+            @"SELECT url, MIN(poll_interval_seconds) pollIntervalSeconds, auth_header authHeader
                 FROM host
                 GROUP BY url"
         );

--- a/src/Mira/Modules/Polling/Polling.Core/Repositories/QueryRepository.cs
+++ b/src/Mira/Modules/Polling/Polling.Core/Repositories/QueryRepository.cs
@@ -1,6 +1,6 @@
 using Dapper;
-using Polling.Core.Models;
 using Shared.Core;
+using Shared.Core.Models;
 
 namespace Polling.Core.Repositories;
 

--- a/src/Mira/Modules/Polling/Polling.Core/SubscriptionManager.cs
+++ b/src/Mira/Modules/Polling/Polling.Core/SubscriptionManager.cs
@@ -26,7 +26,7 @@ public class SubscriptionManager(IChangeTrackingService service, ILogger<Subscri
         {
             try
             {
-                await service.ExecuteAsync(host.Url);
+                await service.ExecuteAsync(host);
             }
             catch (Exception ex)
             {

--- a/src/Mira/Modules/Polling/Polling.Core/SubscriptionManager.cs
+++ b/src/Mira/Modules/Polling/Polling.Core/SubscriptionManager.cs
@@ -1,7 +1,7 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
-using Polling.Core.Models;
 using Shared.Core.Interfaces;
+using Shared.Core.Models;
 
 namespace Polling.Core;
 

--- a/src/Mira/Modules/Shared/Shared.Core/Interfaces/IChangeTrackingService.cs
+++ b/src/Mira/Modules/Shared/Shared.Core/Interfaces/IChangeTrackingService.cs
@@ -1,6 +1,8 @@
+using Shared.Core.Models;
+
 namespace Shared.Core.Interfaces;
 
 public interface IChangeTrackingService
 {
-    Task ExecuteAsync(string hostUrl);
+    Task ExecuteAsync(Host host);
 }

--- a/src/Mira/Modules/Shared/Shared.Core/Models/Host.cs
+++ b/src/Mira/Modules/Shared/Shared.Core/Models/Host.cs
@@ -1,9 +1,10 @@
-namespace Polling.Core.Models;
+namespace Shared.Core.Models;
 
 public class Host
 {
     public string Url { get; set; } = null!;
     public int PollIntervalSeconds { get; set; }
+    public string? AuthHeader { get; set; }
     public TimeSpan PollInterval =>
         PollIntervalSeconds < 30 ? TimeSpan.FromSeconds(30) : TimeSpan.FromSeconds(PollIntervalSeconds);
 }


### PR DESCRIPTION
- Added a new options to the `/add-host` command that allows you to provide an optional auth header
- Added a new environment variable for providing a fallback auth header for a given host
    - This can be set in the appsettings under `FallbackAuthHeaders` or by environment variable
    - Due to limitations of environment variable keys in my hosting provider, the key should be a host name, without any scheme, with the `.` replaced by `_`. For example `"www_broadcastbox_co_uk": "Bearer my-bearer-value"`
 - Updated code to handle new provided auth header, storing it in the DB where required